### PR TITLE
.NET Framework for Unity 2021.2 and above

### DIFF
--- a/doc_projects/docs/Installation.md
+++ b/doc_projects/docs/Installation.md
@@ -8,7 +8,7 @@ There are two ways to install bmlTUX.
 
 For both methods, you should be in a new unity project that meets the [Requirements](Requirements.md)
 
-* Make sure you are targetting .NET 4.x in the Project Settings > Player > Other
+* Make sure you are targetting .NET 4.x (.NET Framework if you are using Unity 2021.2 or later) in the Project Settings > Player > Other
 * Make sure you have TextMeshPro version 2.1 or later installed. Go to Window > Package Manager, and look for TextMeshPro in the list.
 * _IMPORTANT:_ Make sure TextMeshPro Essentials are already imported. Go to Window > TextMeshPro > Import Essentials. Doing this after installing bmlTUX can cause display issues.
 

--- a/doc_projects/docs/Troubleshooting.md
+++ b/doc_projects/docs/Troubleshooting.md
@@ -13,7 +13,7 @@ title: Troubleshooting
     * Make sure that your ExperimentRunner script is attached to a gameObject in the scene, and references the appropriate script files in its inspector
 
 * I'm getting compile errors
-    * Make sure your project settings are set up for API Compatibility Level is set to .Net 4.x. (Edit > Project Settings > Player > Other Settings)
+    * Make sure your project settings are set up for API Compatibility Level is set to .Net 4.x or .NET Framework. (Edit > Project Settings > Player > Other Settings)
 
 * I'm getting argument exceptions about columns missing
     * Make sure you've spelled your variables and your access correctly. These errors are usually due to mismatch between the spelling of a variable in your Variable Config file and your custom Trial script. For example if you spelled your variable "Color" **(no u)** but accessed it using `Data["Colour"]` **(with a u)**, you will get an `ArgumentException` error.


### PR DESCRIPTION
I couldn't find .NET 4.x in the Api Compatibility settings and I was getting compile errors. Then I realized .NET 4.x was renamed .NET Framework in Unity 2021.2 and above. I think adding this note will help first-time users with more recent versions of Unity!
