### PR TITLE
fix: corrected the displayed trial and block numbers in the runner panel

### DIFF
--- a/BML_TUX_Project/Packages/bmlTUX/Scripts/UI/RuntimeUI/RunnerWindowUI/ExperimentRunnerPanel.cs
+++ b/BML_TUX_Project/Packages/bmlTUX/Scripts/UI/RuntimeUI/RunnerWindowUI/ExperimentRunnerPanel.cs
@@ -336,11 +336,17 @@ namespace bmlTUX.UI.RuntimeUI {
             RunningStatusText.text = $"Runner is {runningText}.";
 
             var design = runner.RunnableDesign;
-            int currentTrial = (design.TotalTrials / design.BlockCount) * (currentBlockIndex) + currentTrialIndex + 1;
-            if (currentTrial > design.TotalTrials) currentTrial = design.TotalTrials;
+
+            int currentTrial = currentTrialIndex + 1;
+            if (currentTrial > design.TotalTrials) currentTrial -= 1;
 
             string blockText = "";
-            if (design.HasBlocks) blockText = $" (Block {currentBlockIndex} / {design.BlockCount})";
+            if (design.HasBlocks)
+            {
+                int currentBlock = currentBlockIndex + 1;
+                if (currentBlock > design.BlockCount) currentBlock -= 1;
+                blockText = $" (Block {currentBlock} / {design.BlockCount})";
+            }
             CurrentTrialText.text = ($"Running Trial: {currentTrial} of {design.TotalTrials} total{blockText}.");
 
             Image progressPanelImage = ProgressPanel.GetComponent<Image>();


### PR DESCRIPTION
The original implementation adds the number of trials per block after completing each block, whereas the currentTrialIndex is already tracking the total number of trials for the entire experiment. As a result, the displayed trial counter would become too large. 

Also fixed the block counter by adding 1 to it. 